### PR TITLE
Fix: Adjust container padding on mobile for specific sections

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -701,3 +701,14 @@ color: #777;
   height: 100%;
   border: none;
 }
+
+/* Mobile-specific padding adjustments for specific sections */
+@media (max-width: 767px) {
+  #about .container,
+  #services .container,
+  #portfolio .container,
+  #contact .container {
+    padding-left: 10px;
+    padding-right: 10px;
+  }
+}


### PR DESCRIPTION
This commit addresses an issue where content in the About, Services, Gallery, and Contact sections did not appear to extend to the full width of the screen on mobile devices.

The fix involves adding custom CSS to reduce the left and right padding of the .container elements within these specific sections on screens narrower than 768px. This allows the content to sit closer to the screen edges, as per your feedback, while still maintaining a small gutter for readability.

The changes are scoped to mobile views only and do not affect the layout on larger screens.