### PR TITLE
Fix: Prevent horizontal overflow on mobile devices

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6,6 +6,7 @@ body, html {
 	font-weight: 400;
 	width: 100% !important;
 	height: 100% !important;
+	overflow-x: hidden; /* Prevent horizontal scroll as a fallback */
 }
 h2 {
 	margin: 0 0 20px 0;
@@ -319,11 +320,24 @@ header .intro-text {
 }
 #services .service-media img {
 	position: relative;
-	width: 225px;
-	height: 225px;
+	/* width: 225px; -- Rely on img-responsive and parent column for width on mobile */
+	/* height: 225px; -- Rely on img-responsive (height: auto) for aspect ratio on mobile */
+    /* img-responsive class in HTML should provide max-width: 100% and height: auto */
 	border-radius: 50%;
 	border: 10px solid rgba(255,255,255,0.1);
+    display: inline-block; /* Allows text-align:center on parent to work if image is smaller than column */
+    max-width: 100%; /* Reinforce responsiveness */
+    height: auto; /* Reinforce aspect ratio */
 }
+
+/* Maintain fixed size for larger screens if desired, but still allow shrinking if column is too small */
+@media (min-width: 768px) {
+    #services .service-media img {
+        width: 225px;
+        height: 225px;
+    }
+}
+
 #services .service-desc {
 	margin: 10px 10px 40px;
 	text-align: center;


### PR DESCRIPTION
This commit addresses an issue where blank space or horizontal scrolling occurred on the right side of the screen on mobile devices.

The primary cause was identified as fixed dimensions on service images in the "Services" section, which could overflow their containers on narrower screens.

Changes:
- Modified the CSS for `#services .service-media img` to be responsive on mobile by relying on `max-width: 100%` and `height: auto`, while reapplying fixed dimensions for screens 768px and wider.
- Added `overflow-x: hidden;` to the `body` element as a global fallback to prevent horizontal scrollbars if any other minor overflows occur.